### PR TITLE
add waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/RoeiZucker/sixthRep.png?label=ready&title=Ready)](https://waffle.io/RoeiZucker/sixthRep)
 # SixthRep
 
 This project was generated with [angular-cli](https://github.com/angular/angular-cli) version 1.0.0-beta.19-3.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/RoeiZucker/sixthRep

This was requested by a real person (user RoeiZucker) on waffle.io, we're not trying to spam you.